### PR TITLE
added early return after reject to prevent hitting resolve

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -13,11 +13,15 @@ module.exports = class ServiceManager{
 	execute(Command, JsonEncoded = false){
 		return new Promise((resolve, reject)=>{
 			ChildProcess.exec(Command, {}, (err, stdout, stderr)=>{
-				if(err)
+				if(err) {
 					reject(err);
-
-				if(stderr)
+					return;
+				}
+					
+				if(stderr) {
 					reject(stderr);
+					return;
+				}
 
 				resolve(JsonEncoded ? JSON.parse(stdout) : stdout);
 			});


### PR DESCRIPTION
Hey,
if the windows service doesn't exist I get an exception on the resolve line. Could you add this early return.

Best Regards,
Frank